### PR TITLE
feat: switch base image from stable to latest tag

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -14,7 +14,7 @@
 # For more information, see: specs/001-implement-modular-build/
 # =============================================================================
 
-ARG BASE_IMAGE="ghcr.io/ublue-os/bluefin-dx:stable@sha256:e32adc140296dac9f277f8e8ed5b2b7f32c25c52db49feee53f1ab5899c948b5"
+ARG BASE_IMAGE="ghcr.io/ublue-os/bluefin-dx:latest"
 
 # =============================================================================
 # Stage 1: Context Layer (Static Build Files)
@@ -37,7 +37,7 @@ COPY cosign.pub /cosign.pub
 # =============================================================================
 # Inherits from Universal Blue's Bluefin-DX (Developer Experience) image
 # with desktop environment pre-configured.
-# Using :stable tag for reproducible builds (Fedora 43)
+# Using :latest tag for newest features (Renovate manages SHA pinning)
 
 FROM ${BASE_IMAGE} AS base
 


### PR DESCRIPTION
## Summary
- Switch from `bluefin-dx:stable` to `bluefin-dx:latest` to get newer features and bug fixes
- Fixes the MOTD variable expansion issue (upstream fix in [ublue-os/bluefin#3940](https://github.com/ublue-os/bluefin/pull/3940))
- Renovate will manage SHA pinning for reproducible builds

## Context
The MOTD was showing literal `${MOTD_IMAGE_NAME}` instead of actual values due to an upstream bug where the old `ublue-motd` package was conflicting with the new MOTD system.

## Test plan
- [ ] Build completes successfully
- [ ] MOTD displays correctly with expanded variables after reboot

🤖 Generated with [Claude Code](https://claude.com/claude-code)