### PR TITLE
fix: move VS Code extensions to runtime installation

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -102,11 +102,9 @@ RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
     . /tmp/versions.env && \
     echo "[dudley-versioning] Replacing version placeholders in hooks..." && \
     echo "[dudley-versioning]   Wallpaper: $WALLPAPER_VERSION" && \
-    echo "[dudley-versioning]   VS Code: $VSCODE_VERSION" && \
     echo "[dudley-versioning]   Welcome: $WELCOME_VERSION" && \
     # Replace placeholders in installed hooks
     replace_version_placeholder /usr/share/ublue-os/user-setup.hooks.d/10-wallpaper-enforcement.sh "$WALLPAPER_VERSION" && \
-    replace_version_placeholder /usr/share/ublue-os/user-setup.hooks.d/20-vscode-extensions.sh "$VSCODE_VERSION" && \
     replace_version_placeholder /usr/share/ublue-os/user-setup.hooks.d/99-first-boot-welcome.sh "$WELCOME_VERSION" && \
     # Install build-info CLI tool to /usr/bin (standard location in OSTree images)
     install -m 0755 /tmp/dudley-versioning/show-build-info.sh /usr/bin/dudley-build-info && \

--- a/build_files/shared/branding.sh
+++ b/build_files/shared/branding.sh
@@ -60,6 +60,14 @@ main() {
 		log "WARNING" "System files directory not found (checked $sys_shared)"
 	fi
 
+	# Copy VS Code extensions list for runtime installation
+	if [[ -f /ctx/vscode-extensions.list ]]; then
+		install -m644 /ctx/vscode-extensions.list /usr/share/ublue-os/vscode-extensions.list
+		log "INFO" "Installed VS Code extensions list to /usr/share/ublue-os/"
+	else
+		log "WARNING" "VS Code extensions list not found at /ctx/vscode-extensions.list"
+	fi
+
 	# Install wallpapers from custom_wallpapers directory
 	local bg_dir="/usr/share/backgrounds/dudley"
 	mkdir -p "$bg_dir"

--- a/build_files/shared/utils/generate-manifest.sh
+++ b/build_files/shared/utils/generate-manifest.sh
@@ -76,24 +76,9 @@ wallpaper_meta=$(printf '{"wallpaper_count": %d, "changed": true}' "$WALLPAPER_C
 echo "[dudley-versioning]   Version: $wallpaper_hash (${#WALLPAPER_DEPS[@]} files, $WALLPAPER_COUNT wallpapers)" >&2
 manifest=$(add_hook_to_manifest "$manifest" "wallpaper" "$wallpaper_hash" "$wallpaper_deps_json" "$wallpaper_meta")
 
-# Compute hash for vscode-extensions hook
-echo "[dudley-versioning] Computing hash for vscode-extensions hook..." >&2
-VSCODE_DEPS=(
-	"$PROJECT_ROOT/build_files/user-hooks/20-vscode-extensions.sh"
-)
-# Add extensions list if it exists
-extension_count=0
-if [[ -f "$PROJECT_ROOT/vscode-extensions.list" ]]; then
-	VSCODE_DEPS+=("$PROJECT_ROOT/vscode-extensions.list")
-	extension_count=$(grep -v '^\s*#' "$PROJECT_ROOT/vscode-extensions.list" | grep -c -v '^\s*$')
-fi
-
-vscode_hash=$(compute_content_hash "${VSCODE_DEPS[@]}")
-vscode_deps_json=$(printf '%s\n' "${VSCODE_DEPS[@]}" | sed "s|$PROJECT_ROOT/||" | jq -R . | jq -s .)
-vscode_meta=$(printf '{"extension_count": %d, "changed": true}' "$extension_count")
-
-echo "[dudley-versioning]   Version: $vscode_hash ($extension_count extensions)" >&2
-manifest=$(add_hook_to_manifest "$manifest" "vscode-extensions" "$vscode_hash" "$vscode_deps_json" "$vscode_meta")
+# NOTE: vscode-extensions hook removed - VS Code Insiders is now installed via homebrew
+# Extensions are installed at runtime when VS Code is first launched
+# See: /usr/share/ublue-os/just/apps.just for the bbrew dudley ide command
 
 # Compute hash for holotree hook (script only, no data dependencies)
 echo "[dudley-versioning] Computing hash for holotree hook..." >&2
@@ -135,6 +120,5 @@ echo "[dudley-versioning] ========================================" >&2
 
 # Export computed hashes for use by Containerfile (optional)
 echo "WALLPAPER_VERSION=$wallpaper_hash"
-echo "VSCODE_VERSION=$vscode_hash"
 echo "HOLOTREE_VERSION=$holotree_hash"
 echo "WELCOME_VERSION=$welcome_hash"

--- a/system_files/shared/usr/share/ublue-os/just/60-dudley.just
+++ b/system_files/shared/usr/share/ublue-os/just/60-dudley.just
@@ -95,3 +95,53 @@ dudley-vscode-insiders:
     echo "Installing VS Code Insiders via Homebrew..."
     brew install --cask visual-studio-code-insiders
     echo "✓ VS Code Insiders installation complete"
+    echo ""
+    echo "Installing extensions..."
+    ujust dudley-vscode-extensions
+    echo ""
+    echo "✓ VS Code Insiders setup complete!"
+
+# Install/update VS Code Insiders extensions from list
+dudley-vscode-extensions:
+    #!/usr/bin/bash
+    set -euo pipefail
+    EXTENSIONS_FILE="/usr/share/ublue-os/vscode-extensions.list"
+    CODE_CMD=""
+
+    # Find VS Code Insiders binary
+    if command -v code-insiders &>/dev/null; then
+        CODE_CMD="code-insiders"
+    elif [ -x "$HOME/.local/share/applications/../bin/code-insiders" ]; then
+        CODE_CMD="$HOME/.local/share/applications/../bin/code-insiders"
+    elif [ -x "/home/linuxbrew/.linuxbrew/bin/code-insiders" ]; then
+        CODE_CMD="/home/linuxbrew/.linuxbrew/bin/code-insiders"
+    else
+        echo "ERROR: VS Code Insiders not found. Install it first with: ujust dudley-vscode-insiders"
+        exit 1
+    fi
+
+    if [ ! -f "$EXTENSIONS_FILE" ]; then
+        echo "ERROR: Extensions list not found at $EXTENSIONS_FILE"
+        exit 1
+    fi
+
+    echo "Installing VS Code Insiders extensions..."
+    installed=0
+    failed=0
+    while IFS= read -r ext || [ -n "$ext" ]; do
+        # Skip empty lines and comments
+        [[ -z "$ext" || "$ext" =~ ^[[:space:]]*# ]] && continue
+        ext=$(echo "$ext" | xargs)  # trim whitespace
+        echo "  Installing: $ext"
+        if $CODE_CMD --install-extension "$ext" --force &>/dev/null; then
+            ((installed++))
+        else
+            echo "    ⚠ Failed to install $ext"
+            ((failed++))
+        fi
+    done < "$EXTENSIONS_FILE"
+
+    echo ""
+    echo "✓ Extensions installed: $installed"
+    [ "$failed" -gt 0 ] && echo "⚠ Extensions failed: $failed"
+    echo "Done!"


### PR DESCRIPTION
## Summary
- Removes vscode-extensions from build-time manifest (fixes build failure)
- Adds `ujust dudley-vscode-extensions` command for runtime installation
- Updates `ujust dudley-vscode-insiders` to auto-install extensions after VS Code install
- Copies extensions list to `/usr/share/ublue-os/` for runtime access

## Context
VS Code Insiders is now installed via homebrew at runtime, not baked into the image. The build was failing because it was looking for the removed `20-vscode-extensions.sh` hook.

## Usage
```bash
# Install VS Code Insiders + all extensions
ujust dudley-vscode-insiders

# Update/reinstall extensions later
ujust dudley-vscode-extensions
```

## Test plan
- [ ] Build completes successfully
- [ ] `ujust dudley-vscode-insiders` installs VS Code and extensions
- [ ] `ujust dudley-vscode-extensions` works standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)