### PR TITLE
ci: replace setup-just action with local composite action

### DIFF
--- a/.github/actions/setup-just/action.yml
+++ b/.github/actions/setup-just/action.yml
@@ -1,0 +1,41 @@
+name: Setup just
+description: Install the just command runner without relying on deprecated Node-based actions
+
+inputs:
+  just-version:
+    description: Version of just to install
+    required: false
+    default: "1.46.0"
+
+runs:
+  using: composite
+  steps:
+    - name: Install just
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        version="${{ inputs.just-version }}"
+        arch="$(uname -m)"
+
+        case "${arch}" in
+          x86_64)
+            target="x86_64-unknown-linux-musl"
+            ;;
+          aarch64|arm64)
+            target="aarch64-unknown-linux-musl"
+            ;;
+          *)
+            echo "Unsupported architecture: ${arch}" >&2
+            exit 1
+            ;;
+        esac
+
+        archive="just-${version}-${target}.tar.gz"
+        url="https://github.com/casey/just/releases/download/${version}/${archive}"
+
+        curl -fsSL "${url}" -o "${RUNNER_TEMP}/${archive}"
+        tar -xzf "${RUNNER_TEMP}/${archive}" -C "${RUNNER_TEMP}" just
+        sudo install -m 0755 "${RUNNER_TEMP}/just" /usr/local/bin/just
+
+        just --version

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -31,6 +31,16 @@
       ],
       "depNameTemplate": "oras-project/oras",
       "datasourceTemplate": "github-releases"
+    },
+    {
+      // Track just version in the local setup action
+      "customType": "regex",
+      "fileMatch": ["^\\.github/actions/setup-just/action\\.yml$"],
+      "matchStrings": [
+        "default: \"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
+      ],
+      "depNameTemplate": "casey/just",
+      "datasourceTemplate": "github-releases"
     }
   ],
 

--- a/.github/workflows/build-disk.yml
+++ b/.github/workflows/build-disk.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Just
-        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
+        uses: ./.github/actions/setup-just
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Just
-        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
+        uses: ./.github/actions/setup-just
 
       - name: Install dependencies
         run: |
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Just
-        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
+        uses: ./.github/actions/setup-just
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Just
-        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
+        uses: ./.github/actions/setup-just
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- Add a local composite action at `.github/actions/setup-just/action.yml` to install `just` directly from GitHub releases.
- Replace `extractions/setup-just` usage with `./.github/actions/setup-just` in `build.yml`, `build-disk.yml`, and `copilot-setup-steps.yml`.
- Add a Renovate regex manager entry to keep the local action’s default `just` version updated automatically.
- Remove dependency on the deprecated Node-based `setup-just` action path in workflows.

## Testing
- Not run (no local workflow execution in this change set).
- Verified workflow references now point to `./.github/actions/setup-just` in all updated workflow files.
- Verified local action handles `x86_64` and `aarch64/arm64`, fails fast on unsupported architectures, and prints `just --version` after install.
- Verified Renovate config includes a regex rule for `.github/actions/setup-just/action.yml` with `casey/just` as the datasource target.