### PR TITLE
Preserve DX image metadata in runtime checks

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -39,6 +39,7 @@ test-unit:
     #!/usr/bin/bash
     set -eoux pipefail
     echo "Running unit tests..."
+    bash tests/test-image-info.sh
     bash tests/test-content-versioning.sh
     bash tests/test-manifest-generation.sh
     echo "✓ Unit tests passed!"

--- a/build_files/shared/00-image-info.sh
+++ b/build_files/shared/00-image-info.sh
@@ -25,6 +25,46 @@ IMAGE_TAG="${IMAGE_TAG:-${DEFAULT_TAG:-latest}}"
 IMAGE_VENDOR="${IMAGE_VENDOR:-joshyorko}"
 VERSION="${VERSION:-$(date +%Y%m%d)}"
 
+# Normalize image references to the contract Bluefin recipes expect:
+# image-ref is the repository ref without a tag, while image-tag carries the tag.
+normalize_transport_ref() {
+	local ref="$1"
+	ref="${ref#ostree-image-signed:docker://}"
+	ref="${ref#docker://}"
+	printf '%s' "$ref"
+}
+
+strip_ref_tag() {
+	local ref="$1"
+	local digestless="${ref%@*}"
+	local last_component="${digestless##*/}"
+
+	if [[ "$last_component" == *:* ]]; then
+		printf '%s' "${digestless%:*}"
+	else
+		printf '%s' "$digestless"
+	fi
+}
+
+ref_tag() {
+	local ref="$1"
+	local digestless="${ref%@*}"
+	local last_component="${digestless##*/}"
+
+	if [[ "$last_component" == *:* ]]; then
+		printf '%s' "${last_component##*:}"
+	else
+		printf '%s' "$IMAGE_TAG"
+	fi
+}
+
+image_name_from_ref() {
+	local ref="$1"
+	local digestless="${ref%@*}"
+	local last_component="${digestless##*/}"
+	printf '%s' "${last_component%%:*}"
+}
+
 # Logging helper
 log() {
 	local level=$1
@@ -35,19 +75,35 @@ log() {
 log "INFO" "START - Generating image-info.json"
 
 # Create directory for image info
-IMAGE_INFO_DIR="/usr/share/ublue-os"
+IMAGE_INFO_DIR="${IMAGE_INFO_DIR:-/usr/share/ublue-os}"
 mkdir -p "$IMAGE_INFO_DIR"
 
 IMAGE_INFO="$IMAGE_INFO_DIR/image-info.json"
-OCI_IMAGE_REF="${IMAGE_REF:-ghcr.io/$IMAGE_VENDOR/$IMAGE_NAME:$IMAGE_TAG}"
-IMAGE_REF="ostree-image-signed:docker://${OCI_IMAGE_REF}"
+OCI_IMAGE_REF="$(normalize_transport_ref "${IMAGE_REF:-ghcr.io/$IMAGE_VENDOR/$IMAGE_NAME:$IMAGE_TAG}")"
+IMAGE_REPOSITORY_REF="$(strip_ref_tag "$OCI_IMAGE_REF")"
+IMAGE_TAG="$(ref_tag "$OCI_IMAGE_REF")"
+BASE_IMAGE_REF="$(normalize_transport_ref "${BASE_IMAGE:-}")"
+BASE_IMAGE_NAME="${BASE_IMAGE_NAME:-$(image_name_from_ref "$BASE_IMAGE_REF")}"
+if [[ -z "$BASE_IMAGE_NAME" ]]; then
+	BASE_IMAGE_NAME="bluefin-dx"
+fi
 
-# Determine image flavor based on name
-image_flavor="main"
-if [[ "${IMAGE_NAME}" =~ nvidia ]]; then
-	image_flavor="nvidia"
-elif [[ "${IMAGE_NAME}" =~ dx ]]; then
-	image_flavor="dx"
+# Determine image flavor from the custom image name and inherited base image.
+image_flavor="${IMAGE_FLAVOR:-}"
+if [[ -z "$image_flavor" ]]; then
+	if [[ "${IMAGE_NAME}" =~ dx || "${BASE_IMAGE_NAME}" =~ dx || "${BASE_IMAGE_REF}" =~ dx ]]; then
+		image_flavor="dx"
+	else
+		image_flavor="main"
+	fi
+
+	if [[ "${IMAGE_NAME}" =~ nvidia || "${BASE_IMAGE_NAME}" =~ nvidia || "${BASE_IMAGE_REF}" =~ nvidia ]]; then
+		if [[ "$image_flavor" == "dx" ]]; then
+			image_flavor="dx-nvidia"
+		else
+			image_flavor="nvidia"
+		fi
+	fi
 fi
 
 # Get Fedora version if available
@@ -72,9 +128,9 @@ cat >"$IMAGE_INFO" <<EOF
   "image-name": "$IMAGE_NAME",
   "image-flavor": "$image_flavor",
   "image-vendor": "$IMAGE_VENDOR",
-  "image-ref": "$IMAGE_REF",
+  "image-ref": "ostree-image-signed:docker://${IMAGE_REPOSITORY_REF}",
   "image-tag": "$IMAGE_TAG",
-  "base-image-name": "${BASE_IMAGE_NAME:-bluefin-dx}",
+  "base-image-name": "$BASE_IMAGE_NAME",
   "fedora-version": "$FEDORA_VERSION",
   "kernel-version": "$KERNEL_VERSION",
   "build-date": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
@@ -86,11 +142,12 @@ log "INFO" "Generated image-info.json:"
 cat "$IMAGE_INFO"
 
 # Update os-release with custom branding
-if [[ -f /usr/lib/os-release ]]; then
+OS_RELEASE_FILE="${OS_RELEASE_FILE:-/usr/lib/os-release}"
+if [[ -f "$OS_RELEASE_FILE" ]]; then
 	log "INFO" "Updating os-release branding..."
 
 	# Create custom os-release additions
-	cat >>/usr/lib/os-release <<EOF
+	cat >>"$OS_RELEASE_FILE" <<EOF
 
 # Dudley's Second Bedroom customizations
 PRETTY_NAME="${IMAGE_PRETTY_NAME}"
@@ -99,7 +156,7 @@ DOCUMENTATION_URL="${DOCUMENTATION_URL}"
 SUPPORT_URL="${SUPPORT_URL}"
 BUG_REPORT_URL="${BUG_SUPPORT_URL}"
 VARIANT="${IMAGE_NAME}"
-VARIANT_ID="${image_flavor}"
+VARIANT_ID="${BASE_IMAGE_NAME}"
 EOF
 fi
 

--- a/system_files/shared/usr/share/ublue-os/just/60-dudley.just
+++ b/system_files/shared/usr/share/ublue-os/just/60-dudley.just
@@ -160,3 +160,32 @@ dudley action="setup" target="all" mode="":
             exit 1
             ;;
     esac
+
+# Dudley already inherits from a DX base image, so Bluefin's generic devmode
+# rebase recipe should not synthesize a sibling image name for this repo.
+devmode:
+    @ujust toggle-devmode
+
+toggle-devmode:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    IMAGE_INFO_FILE="${IMAGE_INFO_FILE:-/usr/share/ublue-os/image-info.json}"
+    image_flavor="$(jq -r '."image-flavor" // ""' "$IMAGE_INFO_FILE")"
+    base_image_name="$(jq -r '."base-image-name" // ""' "$IMAGE_INFO_FILE")"
+
+    if [[ "$image_flavor" =~ dx || "$base_image_name" =~ dx ]]; then
+        echo "Dudley is already built from a developer image."
+        if gum confirm "Install the default development Flatpaks?"; then
+            ADD_DEVMODE=1 ujust install-system-flatpaks 0 1
+        fi
+        if gum confirm "Install extra monospace fonts?"; then
+            brew bundle install --file=/usr/share/ublue-os/homebrew/fonts.Brewfile
+        fi
+        echo "Use ujust dx-group to add your user to the correct groups and complete the installation after rebooting into the development image"
+        exit 0
+    fi
+
+    echo "Dudley is not built from a DX base image."
+    echo "Rebuild with BASE_IMAGE=ghcr.io/ublue-os/bluefin-dx:stable instead of using Bluefin's generic devmode rebase."
+    exit 1

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -18,6 +18,7 @@ declare -a FAILED_TESTS
 
 # Test patterns to run
 TEST_PATTERNS=(
+	"test-image-info.sh"
 	"test-content-versioning.sh"
 	"test-manifest-generation.sh"
 	"test-hook-integration.sh"

--- a/tests/test-image-info.sh
+++ b/tests/test-image-info.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Test image-info metadata contracts used by Bluefin runtime recipes.
+
+set -euo pipefail
+
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+IMAGE_INFO_DIR="$TEST_DIR/ublue-os"
+OS_RELEASE_FILE="$TEST_DIR/os-release"
+mkdir -p "$IMAGE_INFO_DIR"
+cat >"$OS_RELEASE_FILE" <<'EOF'
+VERSION_ID=44
+VARIANT_ID=bluefin-dx
+EOF
+
+IMAGE_NAME="dudleys-second-bedroom" \
+	IMAGE_TAG="latest" \
+	IMAGE_REF="ghcr.io/joshyorko/dudleys-second-bedroom:latest" \
+	BASE_IMAGE="ghcr.io/ublue-os/bluefin-dx:latest@sha256:abc123" \
+	IMAGE_INFO_DIR="$IMAGE_INFO_DIR" \
+	OS_RELEASE_FILE="$OS_RELEASE_FILE" \
+	bash build_files/shared/00-image-info.sh >/tmp/test-image-info.log
+
+IMAGE_INFO="$IMAGE_INFO_DIR/image-info.json"
+
+assert_json() {
+	local query="$1"
+	local expected="$2"
+	local actual
+
+	actual="$(jq -r "$query" "$IMAGE_INFO")"
+	if [[ "$actual" != "$expected" ]]; then
+		echo "FAIL: $query expected '$expected', got '$actual'" >&2
+		exit 1
+	fi
+}
+
+assert_json '."image-ref"' "ostree-image-signed:docker://ghcr.io/joshyorko/dudleys-second-bedroom"
+assert_json '."image-tag"' "latest"
+assert_json '."image-flavor"' "dx"
+assert_json '."base-image-name"' "bluefin-dx"
+
+if ! grep -q '^VARIANT_ID="bluefin-dx"$' "$OS_RELEASE_FILE"; then
+	echo "FAIL: os-release custom VARIANT_ID did not preserve the inherited base variant" >&2
+	exit 1
+fi
+
+echo "PASS: image-info preserves Dudley DX runtime metadata"

--- a/tests/verify-build.sh
+++ b/tests/verify-build.sh
@@ -12,6 +12,7 @@ EXPECTED_WALLPAPER_COUNT=6
 EXPECTED_OS_ID="${EXPECTED_OS_ID:-bluefin}"
 EXPECTED_VERSION_ID="${EXPECTED_VERSION_ID:-}"
 EXPECTED_VARIANT_ID="${EXPECTED_VARIANT_ID:-}"
+EXPECTED_IMAGE_FLAVOR="${EXPECTED_IMAGE_FLAVOR:-dx}"
 EXPECTED_IMAGE_NAME="${IMAGE_NAME##*/}"
 EXPECTED_IMAGE_NAME="${EXPECTED_IMAGE_NAME%:*}"
 EXPECTED_IMAGE_TAG="${IMAGE_NAME##*:}"
@@ -182,6 +183,8 @@ echo "=== Image Metadata ==="
 run_check "build manifest exists" "podman run --rm ${IMAGE_NAME} test -f /etc/dudley/build-manifest.json && echo exists" "exists"
 run_manifest_image_check
 run_check "image-info exists" "podman run --rm ${IMAGE_NAME} test -f /usr/share/ublue-os/image-info.json && echo exists" "exists"
+run_check "image-info flavor preserves base flavor" "podman run --rm ${IMAGE_NAME} jq -r '.\"image-flavor\"' /usr/share/ublue-os/image-info.json" "^$(escape_regex "${EXPECTED_IMAGE_FLAVOR}")$"
+run_check "image-info ref omits tag" "podman run --rm ${IMAGE_NAME} jq -r '.\"image-ref\"' /usr/share/ublue-os/image-info.json" "^ostree-image-signed:docker://[^:]*$"
 run_check "image-info tag" "podman run --rm ${IMAGE_NAME} cat /usr/share/ublue-os/image-info.json | jq -r '.\"image-tag\"'" "^$(escape_regex "${EXPECTED_IMAGE_TAG}")$"
 
 IMAGE_SIZE=$(podman inspect "${IMAGE_NAME}" | jq -r '.[0].Size')


### PR DESCRIPTION
## Summary
- Preserve the runtime image metadata contract for Dudley DX builds by normalizing `image-ref`, `image-tag`, and base image fields in `00-image-info.sh`.
- Detect DX-derived builds from the inherited base image, and keep `base-image-name` and `VARIANT_ID` aligned with the DX base instead of synthesizing a sibling image name.
- Add a Dudley-specific `ujust devmode` path that recognizes DX builds and avoids the generic rebase flow.
- Expand unit and build verification coverage to assert the preserved image-info metadata.

## Testing
- `bash tests/test-image-info.sh`
- `just test-unit`
- `just verify-build localhost/dudleys-second-bedroom latest`
- Not run: full image rebuild in this session