### PR TITLE
Add Dudley terminal shortcut dconf defaults

### DIFF
--- a/build_files/desktop/dconf-defaults.sh
+++ b/build_files/desktop/dconf-defaults.sh
@@ -28,9 +28,14 @@ main() {
 
 	log "INFO" "START"
 
-	# Add dconf defaults here
-	# For now, this is a placeholder
-	log "INFO" "No additional dconf defaults configured yet"
+	log "INFO" "Updating dconf database for Dudley defaults"
+	if command -v dconf >/dev/null 2>&1; then
+		dconf update || {
+			log "WARNING" "dconf update failed (may not be critical)"
+		}
+	else
+		log "WARNING" "dconf command not found, skipping dconf database update"
+	fi
 
 	local end_time duration
 	end_time=$(date +%s)

--- a/system_files/shared/etc/dconf/db/distro.d/99-dudley-terminal-keybindings
+++ b/system_files/shared/etc/dconf/db/distro.d/99-dudley-terminal-keybindings
@@ -1,0 +1,5 @@
+[org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0]
+command='/usr/bin/ptyxis --new-window'
+
+[org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1]
+command='/usr/bin/ptyxis --new-window'

--- a/tests/verify-build.sh
+++ b/tests/verify-build.sh
@@ -174,6 +174,7 @@ run_check "VS Code not baked into image" "podman run --rm ${IMAGE_NAME} bash -lc
 run_check "Dudley just recipes" "podman run --rm ${IMAGE_NAME} test -f /usr/share/ublue-os/just/60-dudley.just && echo exists" "exists"
 run_check "Dudley update override" "podman run --rm ${IMAGE_NAME} bash -lc 'grep -F \"^[[:space:]]*LockLayering\" /usr/share/ublue-os/just/update.just >/dev/null && echo fixed'" "fixed"
 run_check "Dudley system flatpak update uses polkit" "podman run --rm ${IMAGE_NAME} bash -lc 'grep -F \"flatpak update -y\" /usr/share/ublue-os/just/update.just >/dev/null && ! grep -E \"sudo[[:space:]]+flatpak[[:space:]]+update\" /usr/share/ublue-os/just/update.just >/dev/null && echo fixed'" "fixed"
+run_check "Dudley terminal shortcut opens new Ptyxis window" "podman run --rm ${IMAGE_NAME} bash -lc 'grep -F \"command='\\''/usr/bin/ptyxis --new-window'\\''\" /etc/dconf/db/distro.d/99-dudley-terminal-keybindings | wc -l'" "2"
 
 # Note: RCC is now installed via Homebrew (ujust dudley brew dev) instead of being baked into the image
 


### PR DESCRIPTION
## Summary
- Adds Dudley dconf defaults for a terminal shortcut that launches `ptyxis --new-window`.
- Updates the dconf defaults script to run `dconf update` when the command is available, with warnings if it is not.
- Extends build verification to confirm the shortcut entries are present in the image.

## Testing
- `Not run`
- Build verification check added in `tests/verify-build.sh` to assert `/etc/dconf/db/distro.d/99-dudley-terminal-keybindings` contains the expected Ptyxis command entries.