### PR TITLE
[codex] Bake Google Chrome into Dudley image

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3,7 +3,8 @@
     "install": [
       "tmux",
       "curl",
-      "gcc-c++"
+      "gcc-c++",
+      "google-chrome-stable"
     ],
     "remove": []
   }

--- a/system_files/shared/etc/yum.repos.d/google-chrome.repo
+++ b/system_files/shared/etc/yum.repos.d/google-chrome.repo
@@ -1,0 +1,6 @@
+[google-chrome]
+name=google-chrome
+baseurl=https://dl.google.com/linux/chrome/rpm/stable/x86_64
+enabled=1
+gpgcheck=1
+gpgkey=https://dl.google.com/linux/linux_signing_key.pub

--- a/tests/verify-build.sh
+++ b/tests/verify-build.sh
@@ -143,6 +143,7 @@ echo "=== Installed Packages ==="
 run_check "tmux" "podman run --rm ${IMAGE_NAME} rpm -q tmux" "tmux-"
 run_check "curl" "podman run --rm ${IMAGE_NAME} rpm -q curl" "curl-"
 run_check "gcc-c++" "podman run --rm ${IMAGE_NAME} rpm -q gcc-c++" "gcc-c++-"
+run_check "Google Chrome" "podman run --rm ${IMAGE_NAME} rpm -q google-chrome-stable" "google-chrome-stable-"
 
 # Check 5: Custom Branding
 echo ""


### PR DESCRIPTION
## Summary
- Add the official Google Chrome RPM repository during the image build.
- Install google-chrome-stable through the existing packages.json path.
- Verify the built image contains the Chrome RPM in tests/verify-build.sh.

## Why
Flatpak Chrome makes Codex Desktop native messaging brittle because the extension host lives on the host while Chrome runs in a sandbox. Baking native Chrome into the image gives Dudley the direct native messaging path.

## Checks
- just check
- pre-commit hooks from git commit

Not run: full image build.
