### PR TITLE
[codex] Deprecate legacy Dudley image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches:
       - main
-  schedule:
-    - cron: '00 21 * * *'  # 9:00pm UTC everyday (5:00pm EDT / 4:00pm EST)
   push:
     branches:
       - main
@@ -32,7 +30,7 @@ on:
         type: boolean
 
 env:
-  IMAGE_DESC: "My Customized Universal Blue Image"
+  IMAGE_DESC: "Deprecated legacy Dudley image; use dudley-os plus dsb-common"
   IMAGE_KEYWORDS: "bootc,ublue,universal-blue"
   IMAGE_LOGO_URL: "https://avatars.githubusercontent.com/u/120078124?s=200&v=4"  # Put your own image here for a fancy profile on https://artifacthub.io/!
   IMAGE_NAME: "${{ github.event.repository.name }}"  # output image name, usually same as repo name
@@ -249,7 +247,7 @@ jobs:
             org.opencontainers.image.url=https://github.com/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}/tree/${{ github.sha }}
             org.opencontainers.image.vendor=${{ github.repository_owner }}
             org.opencontainers.image.version=${{ steps.resolve-build-config.outputs.primary_tag }}.{{date 'YYYYMMDD'}}
-            io.artifacthub.package.deprecated=false
+            io.artifacthub.package.deprecated=true
             io.artifacthub.package.keywords=${{ env.IMAGE_KEYWORDS }}
             io.artifacthub.package.license=Apache-2.0
             io.artifacthub.package.logo-url=${{ env.IMAGE_LOGO_URL }}

--- a/.github/workflows/validate-renovate.yml
+++ b/.github/workflows/validate-renovate.yml
@@ -26,10 +26,10 @@ jobs:
       - name: Install dependencies
         shell: bash
         env:
-          # Keep validation deterministic so strict mode doesn't drift on config aliases.
+          # Keep validation deterministic so config aliases do not drift.
           RENOVATE_VERSION: 43.130.0
         run: npm install -g renovate@${RENOVATE_VERSION}
 
       - name: Validate Renovate config
         shell: bash
-        run: renovate-config-validator --strict
+        run: renovate-config-validator

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # Dudley's Second Bedroom
 
+> **Deprecated:** Active Dudley image work has moved to [`joshyorko/dudley-os`](https://github.com/joshyorko/dudley-os) for final OS assembly and [`joshyorko/dsb-common`](https://github.com/joshyorko/dsb-common) for shared Dudley payload. This repository remains as legacy migration source material for the older monolithic image.
+
 A step up from the closet under the stairs, but not quite the Room of Requirement yet.
 
 This [Universal Blue](https://github.com/ublue-os/main) image extends the [Bluefin](https://github.com/ublue-os/bluefin) flavor with personalized modifications - your own space that's better than where you started, but with room to grow into something even better.


### PR DESCRIPTION
## Summary

- Add a top-of-file deprecation notice pointing active Dudley OS work to `joshyorko/dudley-os` and shared payload work to `joshyorko/dsb-common`.
- Remove the scheduled legacy image build.
- Mark the Artifact Hub package as deprecated and update the image description accordingly.
- Fix the Renovate validator workflow command for Renovate 43 by dropping the removed `--strict` flag.

## Why

The monolithic `dudleys-second-bedroom` image is now legacy migration source material. Active final assembly belongs in `dudley-os`, and reusable Dudley payload belongs in `dsb-common`.

## Related PRs

- `joshyorko/dsb-common#9`
- `joshyorko/dudley-os#10`

## Validation

- Python YAML parse of modified workflow files using a temporary `/tmp` PyYAML venv.
- `npx -y --package renovate@43.130.0 renovate-config-validator`.
- `git diff --check`.
- Existing pre-commit hook ran during commit and passed: trailing whitespace, EOF, YAML, large files, merge conflicts, mixed line ending, and applicable shell/package/module checks.